### PR TITLE
Allow .Find(criteria) when criteria doesn't have a where clause

### DIFF
--- a/src/Catnap/Citeria/Conditions/Criteria.cs
+++ b/src/Catnap/Citeria/Conditions/Criteria.cs
@@ -258,8 +258,12 @@ namespace Catnap.Citeria.Conditions
                 conditionSqls.Add(commandSpec.CommandText);
                 parameters.AddRange(commandSpec.Parameters);
             }
-            commandText = string.Format("({0})",
-                string.Join(string.Format(" {0} ", conjunction.Trim()), conditionSqls.ToArray()));
+			if (conditionSqls.Count > 0) {
+				commandText = string.Format ("({0})",
+				                             string.Join (string.Format (" {0} ", conjunction.Trim ()), conditionSqls.ToArray ()));
+			} else {
+				commandText = string.Empty;
+			}
         }
 
         private string Visit(IConditionMarker condition, ISession session)

--- a/src/Catnap/Mapping/Impl/EntityMap.cs
+++ b/src/Catnap/Mapping/Impl/EntityMap.cs
@@ -179,7 +179,12 @@ namespace Catnap.Mapping.Impl
 
         public IDbCommand GetListCommand(IEnumerable<Parameter> parameters, string whereSql, IDbCommandFactory commandFactory)
         {
-            return commandFactory.Create(parameters, BaseSelectSql + " where " + whereSql);
+			string sql = BaseSelectSql;
+			if (!string.IsNullOrEmpty(whereSql))
+			{
+				sql = sql + " where " + whereSql;
+			}
+			return commandFactory.Create(parameters, sql);
         }
 
         public IDbCommand GetListAllCommand(IDbCommandFactory commandFactory)


### PR DESCRIPTION
Allow a criteria without any where clause. Returns all results.  Previously it add " where () " to the clause, which is invalid sql syntax.

var repo = new MyRepository ();
var criteria = Criteria.For<MyEntity> ();
var results = repo.Find (criteria);
