### PR TITLE
Fix to make update work when Id column name is not "Id"

### DIFF
--- a/src/Catnap/Mapping/Impl/EntityMap.cs
+++ b/src/Catnap/Mapping/Impl/EntityMap.cs
@@ -279,7 +279,7 @@ namespace Catnap.Mapping.Impl
                 dbAdapter.Quote(TableName),
                 string.Join(",", setPairs.ToArray()),
                 dbAdapter.Quote(idColumnName),
-                dbAdapter.FormatParameterName("Id"));
+                dbAdapter.FormatParameterName(idColumnName));
             
             var columnParamters = columnProperties.Select(map => new Parameter(map.ColumnName, map.GetValue((T)entity)));
             parameters.AddRange(columnParamters);


### PR DESCRIPTION
EntityMap.GetUpdateCommand was not using the idColumnName as the
parameter name.
