### PR TITLE
Changes Needed for Monotouch Device Deployments 

### DIFF
--- a/src/Catnap/Mapping/Impl/BasePropertyMap.cs
+++ b/src/Catnap/Mapping/Impl/BasePropertyMap.cs
@@ -17,12 +17,16 @@ namespace Catnap.Mapping.Impl
         protected BasePropertyMap(string propertyName)
         {
             PropertyName = propertyName;
+            // -- Added by RD for Monotouch AOT compiler limitations
+            accessStrategy = new PropertyAccessStrategy<TEntity, TProperty>(propertyName);
         }
 
         protected BasePropertyMap(Expression<Func<TEntity, TProperty>> property)
         {
             this.property = property;
             PropertyName = property.GetMemberExpression().Member.Name;
+            // -- Added by RD for Monotouch AOT compiler limitations
+            accessStrategy = new PropertyAccessStrategy<TEntity, TProperty>(property);
         }
 
         public string PropertyName { get; private set; }
@@ -69,10 +73,11 @@ namespace Catnap.Mapping.Impl
 
         public virtual void Done(IDomainMap domainMap)
         {
-            access = access ?? DefaultAccess;
-            accessStrategy = property == null
-                ? access.CreateFor<TEntity, TProperty>(PropertyName)
-                : access.CreateFor(property);
+            // -- Removed by RD due to Monotouch AOT compiler limitations, moved to constructor where type information is known.
+            //access = access ?? DefaultAccess;
+            //accessStrategy = property == null
+            //    ? access.CreateFor<TEntity, TProperty>(PropertyName)
+            //    : access.CreateFor(property);
         }
 
         protected virtual IAccessStrategyFactory DefaultAccess

--- a/src/Catnap/Mapping/Impl/PropertyWithColumnMap.cs
+++ b/src/Catnap/Mapping/Impl/PropertyWithColumnMap.cs
@@ -32,7 +32,7 @@ namespace Catnap.Mapping.Impl
 
         public override void Done(IDomainMap domainMap)
         {
-            base.Done(domainMap);
+            //base.Done(domainMap); RD removed call.
             ColumnName = ColumnName ?? GetDeafultColumnName(domainMap);
         }
 

--- a/src/Catnap/Session.cs
+++ b/src/Catnap/Session.cs
@@ -42,7 +42,9 @@ namespace Catnap
         {
             commandSpec.GuardArgumentNull("commandSpec");
             var command = commandFactory.Create(commandSpec.Parameters, commandSpec.CommandText);
-            return Try(() => ExecuteQuery(command));
+            var result = Try(() => ExecuteQuery(command));
+            command.Dispose (); //RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
+            return result;
         }
 
         public IList<T> List<T>(IDbCommandSpec commandSpec) where T : class, new()
@@ -60,6 +62,7 @@ namespace Catnap
             var command = entityMap.GetListCommand(predicateSpec.Parameters, predicateSpec.CommandText, commandFactory);
             var results = ExecuteQuery(command).Select(x => entityMap.BuildFrom(x, this)).ToList();
             StoreAll(entityMap, results);
+            command.Dispose ();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
             return results;
         }
 
@@ -75,6 +78,7 @@ namespace Catnap
             var command = entityMap.GetListAllCommand(commandFactory);
             var results = ExecuteQuery(command).Select(x => entityMap.BuildFrom(x, this)).ToList();
             StoreAll(entityMap, results);
+            command.Dispose();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
             return results;
         }
 
@@ -90,6 +94,7 @@ namespace Catnap
             var command = entityMap.GetGetCommand(id, commandFactory);
             var result = ExecuteQuery(command).Select(x => entityMap.BuildFrom(x, this)).FirstOrDefault();
             sessionCache.Store(id, result);
+            command.Dispose ();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
             return result;
         }
 
@@ -113,6 +118,7 @@ namespace Catnap
             }
             sessionCache.Store(entityMap.GetId(entity), entity);
             Cascade(entityMap, entity);
+            command.Dispose();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
         }
 
         private void Cascade<T>(IEntityMap<T> entityMap, T entity) where T : class, new()
@@ -131,6 +137,7 @@ namespace Catnap
             var deleteCommand = map.GetDeleteCommand(id, commandFactory);
             Try(deleteCommand.ExecuteNonQuery);
             sessionCache.Store<T>(id, null);
+            deleteCommand.Dispose ();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
         }
 
         public void ExecuteNonQuery(IDbCommandSpec commandSpec)
@@ -139,6 +146,7 @@ namespace Catnap
             commandSpec.GuardArgumentNull("commandSpec");
             var command = commandFactory.Create(commandSpec);
             Try(command.ExecuteNonQuery);
+            command.Dispose ();	//RD
         }
 
         public IList<IDictionary<string, object>> ExecuteQuery(IDbCommand command)
@@ -158,6 +166,7 @@ namespace Catnap
                     result.Add(row);
                 }
                 reader.Close();
+                command.Dispose ();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
                 return result;
             }
         }
@@ -167,7 +176,9 @@ namespace Catnap
             GuardNotDisposed();
             commandSpec.GuardArgumentNull("commandSpec");
             var command = commandFactory.Create(commandSpec);
-            return Try(command.ExecuteScalar);
+            object result = Try(command.ExecuteScalar);
+            command.Dispose();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
+            return result;
         }
 
         public T ExecuteScalar<T>(IDbCommandSpec commandSpec)
@@ -176,6 +187,7 @@ namespace Catnap
             commandSpec.GuardArgumentNull("commandSpec");
             var command = commandFactory.Create(commandSpec);
             var result = Try(command.ExecuteScalar);
+            command.Dispose ();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
             return (T)result;
         }
 
@@ -183,6 +195,7 @@ namespace Catnap
         {
             var getTableMetadataCommand = DbAdapter.CreateGetTableMetadataCommand(tableName, commandFactory);
             var result = ExecuteQuery(getTableMetadataCommand);
+            getTableMetadataCommand.Dispose ();	//RD see http://www.aaronheise.com/2012/12/monotouch-sqlite-sigsegv/
             return result.Count > 0;
         }
 


### PR DESCRIPTION
Numerous changes needed to overcome Monotouch limitations when deploying
to devices. The major issues are with the AOT compiler as well as problems with needing to have to  dispose  commands explicitly.
